### PR TITLE
Fix 405 errors by removing static export configuration

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  output: "export",
   reactCompiler: true,
   images: {
     unoptimized: true,


### PR DESCRIPTION
## Problem

Getting 405 Method Not Allowed errors on Vercel for both  and  endpoints.

## Root Cause

The Next.js config had `output: "export"` which creates a **static export**. Static exports completely remove all API routes during the build process because static sites cannot include server-side functionality.

## Solution

Removed `output: "export"` from `next.config.ts` to allow API routes to work on Vercel.

## References

- [How to Fix 405 Errors on Next.js Hosted on Vercel](https://www.wisp.blog/blog/how-to-fix-405-errors-on-nextjs-hosted-on-vercel)
- [Next.js API routes returning 405 on Vercel](https://github.com/vercel/next.js/issues/55667)

## Testing

✅ Build passes locally
✅ API routes will now be deployed as serverless functions on Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)